### PR TITLE
Fix playlist navigation and continuation

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -2,12 +2,13 @@ import { Operation, operation } from 'userscripter/lib/operations'
 import { ALWAYS, DOMCONTENTLOADED } from 'userscripter/lib/environment'
 import { get as CookieGet } from 'js-cookie'
 import { YTConfigData } from '~src/youtube'
+import addPlaylistReadyEventHook from '~src/operations/actions/add-playlist-ready-event-hook'
 import addLocationChangeEventHooks from '~src/operations/actions/add-location-change-event-hook'
 import isOnPlaylistPage from '~src/operations/conditions/is-on-playlist-page'
 import { XPATH } from '~src/selectors'
 import appendAppToDom from '~src/operations/actions/append-app-to-dom'
 
-function mainWrapper() {
+function mainWrapper(reinit: boolean | undefined = false) {
   const url = new URL(window.location.href)
   const playlistName = url.searchParams.get('list') as string
   /* eslint-disable no-underscore-dangle */
@@ -25,11 +26,7 @@ function mainWrapper() {
     ORIGIN_URL: new URL(document.URL).origin,
   }
 
-  document.addEventListener('yt-action', (event: any) => {
-    if (event.detail.actionName === 'yt-service-request') {
-      appendAppToDom(config, playlistName, XPATH.APP_RENDER_ROOT)
-    }
-  })
+  appendAppToDom(config, playlistName, XPATH.APP_RENDER_ROOT, reinit)
 }
 
 // Called every time app navigation occurs
@@ -44,7 +41,7 @@ const OPERATIONS: ReadonlyArray<Operation<any>> = [
     description: 'run main if the script start on playlist page',
     condition: isOnPlaylistPage,
     action: () => {
-      mainWrapper()
+      addPlaylistReadyEventHook(mainWrapper)
     },
     deferUntil: DOMCONTENTLOADED,
   }),

--- a/src/operations/actions/add-playlist-ready-event-hook.ts
+++ b/src/operations/actions/add-playlist-ready-event-hook.ts
@@ -1,0 +1,20 @@
+// Add playlist ready event hook
+function addPlaylistReadyEventHook(callback: (reinit?: boolean | undefined) => void): void {
+  document.addEventListener('yt-action', (event: Event) => {
+    if ((event as CustomEvent).detail.actionName === 'yt-service-request') {
+      const { target } = event
+
+      if (target instanceof Element) {
+        if ([...target.classList].includes('ytd-masthead')) {
+          callback()
+        }
+
+        if ([...target.classList].includes('ytd-section-list-renderer')) {
+          callback(true)
+        }
+      }
+    }
+  })
+}
+
+export default addPlaylistReadyEventHook

--- a/src/operations/actions/append-app-to-dom.tsx
+++ b/src/operations/actions/append-app-to-dom.tsx
@@ -4,9 +4,10 @@ import RemoveVideoEnhancerApp from '~components/remove-video-enhancer-app'
 import { YTConfigData } from '~src/youtube'
 import U from '~src/userscript'
 
-export default function appendAppToDom(config: YTConfigData, playlistName: string, xpathRoot: string) {
+export default function appendAppToDom(config: YTConfigData, playlistName: string, xpathRoot: string, reinit: boolean) {
   const existingElement = document.querySelector(`#${U.id}${playlistName}`)
-  if (!existingElement) {
+
+  if (!existingElement || reinit) {
     const elementToAppendTo = getElementsByXpath(xpathRoot)
       // get only currently visibles elements because youtube hide elements instead of removing them from the DOM
       .find((element: any) => element.offsetHeight > 0 || element.offsetWidth > 0) as Element


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes playlist navigation which appears to have been broken in #143.

This also fixes #290 by adding additional `yt-service-request` actions when playlist continuations are loaded.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
