### PR TITLE
Use setVideoId instead of videoId 

### DIFF
--- a/src/components/remove-video-enhancer-app.tsx
+++ b/src/components/remove-video-enhancer-app.tsx
@@ -74,10 +74,12 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
     }
   }
 
-  async removeVideoHandler(videoId: string) {
+  async removeVideoHandler(setVideoId: string) {
     const { playlist } = this.state
     if (playlist && playlist.continuations[0].videos.length > 0) {
-      const [toDeleteVideos, toKeepVideos] = partition(playlist.continuations[0].videos, (v) => v.videoId === videoId)
+      const [toDeleteVideos, toKeepVideos] = partition(playlist.continuations[0].videos, (v) => {
+        return v.setVideoId === setVideoId
+      })
       if (toDeleteVideos.length > 0) {
         try {
           await removeVideosFromPlaylist(playlist?.playlistId as string, toDeleteVideos)

--- a/src/components/remove-video-enhancer-container.tsx
+++ b/src/components/remove-video-enhancer-container.tsx
@@ -11,7 +11,7 @@ import VideoItemQuickDeleteButton from './video-item-quick-delete-button'
 interface Properties {
   removeVideoWatchedPercentHandler: (watchTimeValue: number) => Promise<void> | void
   resetVideoHandler: (videoId: string) => Promise<void> | void
-  removeVideoHandler: (videoId: string) => Promise<void> | void
+  removeVideoHandler: (setVideoId: string) => Promise<void> | void
   initialValue?: number
 }
 
@@ -42,8 +42,8 @@ function RemoveVideoEnhancerContainer({
     }
   }
 
-  const removeVideo = useCallback(async (videoId: string) => {
-    await removeVideoHandler(videoId)
+  const removeVideo = useCallback(async (setVideoId: string) => {
+    await removeVideoHandler(setVideoId)
   }, [])
 
   const resetVideo = useCallback(async (videoId: string) => {
@@ -63,7 +63,7 @@ function RemoveVideoEnhancerContainer({
           }),
           h(VideoItemQuickDeleteButton, {
             // @ts-ignore element.data does not exists on types
-            videoId: element.parentElement?.data.videoId,
+            setVideoId: element.parentElement?.data.setVideoId,
             onClick: removeVideo,
           }),
         ],

--- a/src/components/video-item-quick-delete-button.tsx
+++ b/src/components/video-item-quick-delete-button.tsx
@@ -2,7 +2,10 @@ import { useState } from 'preact/hooks'
 
 import IconButton from 'preact-material-components/IconButton'
 
-function VideoItemQuickDeleteButton(properties: { videoId: string; onClick: (videoId: string) => Promise<void> }) {
+function VideoItemQuickDeleteButton(properties: {
+  setVideoId: string
+  onClick: (setVideoId: string) => Promise<void>
+}) {
   const [loading, setLoading] = useState(false)
   return (
     <IconButton
@@ -10,7 +13,7 @@ function VideoItemQuickDeleteButton(properties: { videoId: string; onClick: (vid
       style={{ order: -1 }}
       onClick={async () => {
         setLoading(true)
-        await properties.onClick(properties.videoId)
+        await properties.onClick(properties.setVideoId)
         setLoading(false)
       }}
       disabled={loading}

--- a/src/operations/actions/remove-videos-from-playlist-ui.ts
+++ b/src/operations/actions/remove-videos-from-playlist-ui.ts
@@ -2,9 +2,9 @@ import removeVideosFromPlaylist from '~src/operations/ui/remove-videos-from-play
 import decrementNumberOfVideosInPlaylist from '~src/operations/ui/decrement-number-of-videos-in-playlist'
 import { PlaylistVideo } from '~src/youtube'
 
-export function removeVideoFromPlaylistUI(videoId: string) {
+export function removeVideoFromPlaylistUI(setVideoId: string) {
   try {
-    removeVideosFromPlaylist([{ videoId, percentDurationWatched: 100 }])
+    removeVideosFromPlaylist([{ setVideoId, percentDurationWatched: 100 }])
     decrementNumberOfVideosInPlaylist(1)
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/operations/ui/remove-videos-from-playlist.ts
+++ b/src/operations/ui/remove-videos-from-playlist.ts
@@ -31,16 +31,16 @@ export default function removeVideosFromPlaylist(videosToDelete: PlaylistVideo[]
     const searchMap = listMapSearch(
       uniqueVideosToDelete,
       playlistVideoRendererNodes,
-      (video) => video.videoId,
-      (node) => node.data.videoId,
+      (video) => video.setVideoId,
+      (node) => node.data.setVideoId,
     )
     // if all videos to remove are present in the UI
     if (searchMap) {
       const htmlElements = Object.values(searchMap)
       for (const element of htmlElements) {
         // eslint-disable-next-line no-underscore-dangle
-        const videoId = element.data.setVideoId
-        removeVideoWithYtAction(videoId)
+        const { setVideoId } = element.data
+        removeVideoWithYtAction(setVideoId)
       }
       return
     }

--- a/src/youtube.d.ts
+++ b/src/youtube.d.ts
@@ -26,7 +26,8 @@ export interface YTConfigData {
 }
 
 export interface PlaylistVideo {
-  videoId: string
+  videoId?: string
+  setVideoId: string
   percentDurationWatched: number
 }
 

--- a/src/yt-api.ts
+++ b/src/yt-api.ts
@@ -1,4 +1,4 @@
-import { Innertube } from "youtubei.js"
+import { Innertube } from 'youtubei.js'
 import { PlaylistNotEditableError, PlaylistEmptyError } from '~src/errors'
 import { YTConfigData, PlaylistVideo, Playlist, PlaylistContinuation } from './youtube'
 
@@ -33,19 +33,23 @@ async function fetchPlaylistInitialData(config: YTConfigData, playlistName: stri
   const youtube = await Innertube.create({
     cookie: document.cookie,
     fetch: (input, init = {}) => {
-      const headers = new Headers();
+      const headers = new Headers()
       headers.append('X-YouTube-Client-Name', config.INNERTUBE_CONTEXT_CLIENT_NAME)
       headers.append('X-YouTube-Client-Version', config.INNERTUBE_CONTEXT_CLIENT_VERSION)
       headers.append('X-YouTube-Device', config.DEVICE)
       headers.append('X-YouTube-Identity-Token', config.ID_TOKEN)
-      init.headers = headers;
-      return fetch(input, init);
-    }
-  });
+      const options = { ...init, headers }
+      return fetch(input, options)
+    },
+  })
 
-  const response = await youtube.session.http.fetch(`/playlist?list=${playlistName}&pbj=1`, {baseURL: 'https://www.youtube.com'});
-  const data = (await response.json()).response.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content
-    .sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer;
+  const response = await youtube.session.http.fetch(`/playlist?list=${playlistName}&pbj=1`, {
+    baseURL: 'https://www.youtube.com',
+  })
+  const json = await response.json()
+  const data =
+    json.response.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[0]
+      .itemSectionRenderer.contents[0].playlistVideoListRenderer
 
   if (!data) {
     throw PlaylistEmptyError
@@ -59,15 +63,13 @@ async function fetchPlaylistInitialData(config: YTConfigData, playlistName: stri
   }
 }
 
-async function fetchPlaylistContinuation(
-  continuation: PlaylistContinuation
-): Promise<PlaylistContinuation> {
+async function fetchPlaylistContinuation(continuation: PlaylistContinuation): Promise<PlaylistContinuation> {
   const youtube = await Innertube.create({
     cookie: document.cookie,
-    fetch: (...args) => fetch(...args),
+    fetch: (...arguments_) => fetch(...arguments_),
   })
 
-  const body = {continuation: continuation.continuationToken}
+  const body = { continuation: continuation.continuationToken }
   const result = await youtube.actions.execute('/browse', body)
   const data = result.data.onResponseReceivedActions?.[0].appendContinuationItemsAction.continuationItems
 
@@ -100,7 +102,7 @@ export async function fetchAllPlaylistContent(config: YTConfigData, playlistName
 async function getFeedbackToken(videoId: string): Promise<string | undefined> {
   const youtube = await Innertube.create({
     cookie: document.cookie,
-    fetch: (...args) => fetch(...args),
+    fetch: (...arguments_) => fetch(...arguments_),
   })
 
   const history = await youtube.getHistory()
@@ -119,10 +121,10 @@ async function getFeedbackToken(videoId: string): Promise<string | undefined> {
 async function sendFeedbackRequest(feedbackToken: string) {
   const youtube = await Innertube.create({
     cookie: document.cookie,
-    fetch: (...args) => fetch(...args),
+    fetch: (...arguments_) => fetch(...arguments_),
   })
 
-  const body = {feedbackTokens: [feedbackToken]}
+  const body = { feedbackTokens: [feedbackToken] }
   const result = await youtube.actions.execute('/feedback', body)
   const response = result.data
 
@@ -138,19 +140,14 @@ export async function removeWatchHistoryForVideo(videoId: string) {
   }
 }
 
-export async function removeVideosFromPlaylist(
-  playlistId: string,
-  videosToRemove: PlaylistVideo[],
-): Promise<boolean> {
+export async function removeVideosFromPlaylist(playlistId: string, videosToRemove: PlaylistVideo[]) {
   const youtube = await Innertube.create({
     cookie: document.cookie,
-    fetch: (...args) => fetch(...args),
+    fetch: (...arguments_) => fetch(...arguments_),
   })
 
-  try {
-    await youtube.playlist.removeVideos(playlistId, videosToRemove.map(({ videoId }) => videoId))
-    return true
-  } catch (error) {
-    return false
-  }
+  await youtube.playlist.removeVideos(
+    playlistId,
+    videosToRemove.map(({ videoId }) => videoId),
+  )
 }

--- a/src/yt-api.ts
+++ b/src/yt-api.ts
@@ -6,6 +6,7 @@ function extractPlaylistVideoListRendererContents(playlistVideoListContents: Arr
   return playlistVideoListContents.map((item): PlaylistVideo => {
     return {
       videoId: item.playlistVideoRenderer.videoId,
+      setVideoId: item.playlistVideoRenderer.setVideoId,
       percentDurationWatched:
         item.playlistVideoRenderer.thumbnailOverlays[1].thumbnailOverlayResumePlaybackRenderer
           ?.percentDurationWatched || 0,
@@ -146,8 +147,13 @@ export async function removeVideosFromPlaylist(playlistId: string, videosToRemov
     fetch: (...arguments_) => fetch(...arguments_),
   })
 
-  await youtube.playlist.removeVideos(
-    playlistId,
-    videosToRemove.map(({ videoId }) => videoId),
-  )
+  const body = {
+    playlist_id: playlistId,
+    actions: videosToRemove.map((video) => ({
+      action: 'ACTION_REMOVE_VIDEO',
+      set_video_id: video.setVideoId,
+    })),
+  }
+
+  await youtube.actions.execute('/browse/edit_playlist', body)
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -33,10 +33,10 @@ webpackConfig.optimization = {
 export default {
   ...webpackConfig,
   resolve: {
-      ...webpackConfig.resolve,
-      alias: {
-          ...webpackConfig.resolve?.alias,
-          'youtubei.js': 'node_modules/youtubei.js/bundle/browser.js'
-      },
+    ...webpackConfig.resolve,
+    alias: {
+      ...webpackConfig.resolve?.alias,
+      'youtubei.js': 'node_modules/youtubei.js/bundle/browser.js',
+    },
   },
-};
+}


### PR DESCRIPTION
## Description

This allows videos to be removed on a playlist level, this enables the removal of videos when there are duplicates in a playlist.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
